### PR TITLE
Message Command Flags

### DIFF
--- a/example/modules/Commands/Flags.js
+++ b/example/modules/Commands/Flags.js
@@ -1,0 +1,25 @@
+import { MessageCommandBuilder } from "reciple";
+
+export class Message {
+    commands = [
+        new MessageCommandBuilder()
+            .setName('flag')
+            .setDescription('Sends a message')
+            .addFlag(flag => flag
+                .setName('flag')
+                .setDescription('A flag')
+                .setAccept('string')
+                .setRequired(true)
+                .setMandatory(true)
+            )
+            .setExecute(async ({ message, flags }) => {
+                await message.reply(flags.getFlagValues('flag')[0]);
+            })
+    ];
+
+    onStart() {
+        return true;
+    }
+}
+
+export default new Message()

--- a/example/modules/Commands/Flags.js
+++ b/example/modules/Commands/Flags.js
@@ -1,4 +1,6 @@
+// @ts-check
 import { MessageCommandBuilder } from "reciple";
+import { createMessageCommandUsage } from '@reciple/message-command-utils';
 
 export class Message {
     commands = [
@@ -8,16 +10,18 @@ export class Message {
             .addFlag(flag => flag
                 .setName('flag')
                 .setDescription('A flag')
-                .setAccept('string')
+                .setValueType('string')
                 .setRequired(true)
                 .setMandatory(true)
             )
             .setExecute(async ({ message, flags }) => {
-                await message.reply(flags.getFlagValues('flag')[0]);
+                await message.reply(flags.getFlagValues('flag', { required: true, type: 'string' })[0]);
             })
     ];
 
     onStart() {
+        logger.log(this.commands[0])
+        logger.log(createMessageCommandUsage(this.commands[0]))
         return true;
     }
 }

--- a/example/modules/Commands/Say.js
+++ b/example/modules/Commands/Say.js
@@ -1,5 +1,4 @@
 // @ts-check
-
 import { SlashCommandBuilder } from 'reciple';
 
 /**

--- a/example/modules/Halts/MessageCommandArguments.js
+++ b/example/modules/Halts/MessageCommandArguments.js
@@ -13,9 +13,12 @@ export class MessageCommandArguments {
      * @param {import('reciple').MessageCommandHaltTriggerData} data 
      */
     async messageCommandHalt(data) {
-        if (data.reason !== CommandHaltReason.InvalidArguments && data.reason !== CommandHaltReason.MissingArguments) return;
-        console.log(data.executeData.options.invalidOptions);
-        console.log(data.executeData.options.missingOptions);
+        if (
+            data.reason !== CommandHaltReason.InvalidArguments &&
+            data.reason !== CommandHaltReason.MissingArguments &&
+            data.reason !== CommandHaltReason.InvalidFlags &&
+            data.reason !== CommandHaltReason.MissingFlags
+        ) return;
 
         switch (data.reason) {
             case CommandHaltReason.InvalidArguments:
@@ -23,6 +26,12 @@ export class MessageCommandArguments {
                 break;
             case CommandHaltReason.MissingArguments:
                 await data.executeData.message.reply(`## Missing arguments\n${data.executeData.options.missingOptions.map(o => `- ${inlineCode(o.name)}`).join('\n')}`);
+                break;
+            case CommandHaltReason.InvalidFlags:
+                await data.executeData.message.reply(`## Invalid flags\n${data.executeData.flags.invalidFlags.map(o => `- ${inlineCode(o.name)} ${o.error?.message ?? 'Invalid value'}`).join('\n')}`);
+                break;
+            case CommandHaltReason.MissingFlags:
+                await data.executeData.message.reply(`## Missing flags\n${data.executeData.flags.missingFlags.map(o => `- ${inlineCode(o.name)}`).join('\n')}`);
                 break;
         }
 

--- a/example/modules/Preconditions/MyPrecondition.js
+++ b/example/modules/Preconditions/MyPrecondition.js
@@ -1,5 +1,4 @@
 // @ts-check
-
 /**
  * @satisfies {import("reciple").CommandPreconditionData}
  */

--- a/example/nodemon.json
+++ b/example/nodemon.json
@@ -8,7 +8,7 @@
     "node_modules/**"
   ],
   "watch": [
-    "src",
+    "modules",
     "reciple.mjs",
     ".env"
   ],

--- a/packages/core/src/classes/builders/ContextMenuCommandBuilder.ts
+++ b/packages/core/src/classes/builders/ContextMenuCommandBuilder.ts
@@ -93,7 +93,7 @@ export class ContextMenuCommandBuilder extends Mixin(DiscordJsContextMenuCommand
     }
 
     public static resolve(data: ContextMenuCommandResolvable): ContextMenuCommandBuilder {
-        return data instanceof ContextMenuCommandBuilder ? data : this.from(data);
+        return data instanceof ContextMenuCommandBuilder ? data : ContextMenuCommandBuilder.from(data);
     }
 
     public static async execute({ client, interaction, command }: ContextMenuCommandExecuteOptions): Promise<ContextMenuCommandExecuteData|null> {

--- a/packages/core/src/classes/builders/MessageCommandBuilder.ts
+++ b/packages/core/src/classes/builders/MessageCommandBuilder.ts
@@ -262,7 +262,8 @@ export class MessageCommandBuilder extends BaseCommandBuilder implements Message
             validate_options: this.validate_options,
             dm_permission: this.dm_permission,
             allow_bot: this.allow_bot,
-            options: this.options,
+            options: this.options.map(b => b.toJSON()),
+            flags: this.flags.map(b => b.toJSON()),
             ...super._toJSON<CommandType.MessageCommand, MessageCommandExecuteFunction>()
         };
     }

--- a/packages/core/src/classes/builders/MessageCommandBuilder.ts
+++ b/packages/core/src/classes/builders/MessageCommandBuilder.ts
@@ -256,12 +256,15 @@ export class MessageCommandBuilder extends BaseCommandBuilder implements Message
                 builder.flags
                     .map((o) => [
                         o.name,
-                        {
-                            type: MessageCommandFlagBuilder.getFlagValuesType(o.default_values ?? []),
-                            multiple: o.multiple,
-                            short: o.short,
-                            default: o.multiple ? o.default_values as string[] : o.default_values?.[0],
-                        }
+                        Object.fromEntries(
+                            Object.entries({
+                                type: o.accept ?? 'string',
+                                multiple: o.multiple,
+                                short: o.short,
+                                default: o.multiple ? o.default_values : o.default_values?.[0],
+                            })
+                            .filter(([key, value]) => value !== undefined)
+                        ) as any
                     ])
             ),
         });

--- a/packages/core/src/classes/builders/MessageCommandBuilder.ts
+++ b/packages/core/src/classes/builders/MessageCommandBuilder.ts
@@ -392,6 +392,28 @@ export class MessageCommandBuilder extends BaseCommandBuilder implements Message
             }
         }
 
+        if (builder.validate_flags) {
+            if (executeData.flags.hasInvalidFlags) {
+                await client.commands.executeHalts({
+                    commandType: builder.command_type,
+                    reason: CommandHaltReason.InvalidFlags,
+                    executeData,
+                    invalidFlags: executeData.flags.invalidFlags
+                });
+                return null;
+            }
+
+            if (executeData.flags.hasMissingFlags) {
+                await client.commands.executeHalts({
+                    commandType: builder.command_type,
+                    reason: CommandHaltReason.MissingFlags,
+                    executeData,
+                    missingFlags: executeData.flags.missingFlags
+                });
+                return null;
+            }
+        }
+
         return (await client.commands.executeCommandBuilderExecute(executeData)) ? executeData : null;
     }
 }

--- a/packages/core/src/classes/builders/MessageCommandBuilder.ts
+++ b/packages/core/src/classes/builders/MessageCommandBuilder.ts
@@ -14,6 +14,7 @@ import { getCommand } from 'fallout-utility/commands';
 import { parseArgs } from 'util';
 import { MessageCommandFlagBuilder, type MessageCommandFlagResolvable } from './MessageCommandFlagBuilder.js';
 import { MessageCommandFlagValidators } from '../validators/MessageCommandFlagValidator.js';
+import { MessageCommandFlagManager } from '../managers/MessageCommandFlagManager.js';
 
 export interface MessageCommandExecuteData {
     type: CommandType.MessageCommand;
@@ -21,6 +22,7 @@ export interface MessageCommandExecuteData {
     message: Message<boolean>;
     parserData: CommandData;
     options: MessageCommandOptionManager;
+    flags: MessageCommandFlagManager;
     builder: MessageCommandBuilder;
 }
 
@@ -283,6 +285,12 @@ export class MessageCommandBuilder extends BaseCommandBuilder implements Message
             builder,
             parserData,
             options: await MessageCommandOptionManager.parseOptions({
+                command: builder,
+                message,
+                parserData,
+                client
+            }),
+            flags: await MessageCommandFlagManager.parseFlags({
                 command: builder,
                 message,
                 parserData,

--- a/packages/core/src/classes/builders/MessageCommandBuilder.ts
+++ b/packages/core/src/classes/builders/MessageCommandBuilder.ts
@@ -297,7 +297,7 @@ export class MessageCommandBuilder extends BaseCommandBuilder implements Message
                         o.name,
                         Object.fromEntries(
                             Object.entries({
-                                type: o.accept ?? 'string',
+                                type: o.value_type ?? 'string',
                                 multiple: o.multiple,
                                 short: o.short,
                                 default: o.multiple ? o.default_values : o.default_values?.[0],

--- a/packages/core/src/classes/builders/MessageCommandBuilder.ts
+++ b/packages/core/src/classes/builders/MessageCommandBuilder.ts
@@ -53,6 +53,11 @@ export interface MessageCommandBuilderData extends BaseCommandBuilderData {
      */
     validate_options?: boolean;
     /**
+     * Whether to validate flags or not.
+     * @default true
+     */
+    validate_flags?: boolean;
+    /**
      * Allows commands to be executed in DMs.
      * @default false
      */
@@ -86,6 +91,7 @@ export class MessageCommandBuilder extends BaseCommandBuilder implements Message
     public description: string = '';
     public aliases: string[] = [];
     public validate_options: boolean = true;
+    public validate_flags: boolean = true;
     public dm_permission: boolean = false;
     public allow_bot: boolean = false;
     public options: MessageCommandOptionBuilder[] = [];
@@ -98,9 +104,11 @@ export class MessageCommandBuilder extends BaseCommandBuilder implements Message
         if (data?.description) this.setDescription(data.description);
         if (data?.aliases) this.setAliases(data.aliases);
         if (data?.validate_options) this.setValidateOptions(data.validate_options);
+        if (data?.validate_flags) this.setValidateFlags(data.validate_flags);
         if (data?.dm_permission) this.setDMPermission(data.dm_permission);
         if (data?.allow_bot) this.setAllowBot(data.allow_bot);
         if (data?.options) this.setOptions(data.options);
+        if (data?.flags) this.setFlags(data.flags);
     }
 
     /**
@@ -156,6 +164,16 @@ export class MessageCommandBuilder extends BaseCommandBuilder implements Message
     }
 
     /**
+     * Set whether to validate flags or not.
+     * @param enabled Enable flag validation.
+     */
+    public setValidateFlags(enabled: boolean): this {
+        MessageCommandValidators.isValidValidateFlags(enabled);
+        this.validate_flags = enabled;
+        return this;
+    }
+
+    /**
      * Sets whether the command is available in DMs or not.
      * @param DMPermission Enable command in Dms.
      */
@@ -206,6 +224,10 @@ export class MessageCommandBuilder extends BaseCommandBuilder implements Message
         return this;
     }
 
+    /**
+     * Adds new flag to the command.
+     * @param option Flag data or builder.
+     */
     public addFlag(option: MessageCommandFlagResolvable|((builder: MessageCommandFlagBuilder) => MessageCommandFlagBuilder)): this {
         const opt = typeof option === 'function' ? option(new MessageCommandFlagBuilder()) : MessageCommandFlagBuilder.resolve(option);
         MessageCommandFlagValidators.isValidMessageCommandFlagResolvable(opt);
@@ -213,6 +235,22 @@ export class MessageCommandBuilder extends BaseCommandBuilder implements Message
         if (this.flags.find(o => o.name === opt.name)) throw new RecipleError('A flag with name "' + opt.name + '" already exists.');
 
         this.flags.push(MessageCommandFlagBuilder.resolve(opt));
+        return this;
+    }
+
+    /**
+     * Sets the flags of the command.
+     * @param flags Flags data or builders.
+     */
+    public setFlags(...flags: RestOrArray<MessageCommandFlagResolvable|((builder: MessageCommandFlagBuilder) => MessageCommandFlagBuilder)>): this {
+        flags = normalizeArray(flags);
+        MessageCommandValidators.isValidFlags(flags);
+        this.flags = [];
+
+        for (const flag of flags) {
+            this.addFlag(flag);
+        }
+
         return this;
     }
 

--- a/packages/core/src/classes/builders/MessageCommandFlagBuilder.ts
+++ b/packages/core/src/classes/builders/MessageCommandFlagBuilder.ts
@@ -1,0 +1,135 @@
+import { isJSONEncodable, normalizeArray, type Awaitable, type JSONEncodable, type Message, type RestOrArray } from 'discord.js';
+import type { CommandData } from '../../types/structures.js';
+import type { MessageCommandBuilder } from './MessageCommandBuilder.js';
+import type { RecipleClient } from '../structures/RecipleClient.js';
+
+export interface MessageCommandFlagBuilderResolveValueOptions<V extends string|boolean = string|boolean, T extends any = V> {
+    /**
+     * The values of the given flag
+     */
+    values: V[];
+    /**
+     * The parser data when parsing this command.
+     */
+    parserData: CommandData;
+    /**
+     * The flag builder used to build this option.
+     */
+    option: MessageCommandFlagBuilder<V, T>;
+    /**
+     * The command builder used to build this command.
+     */
+    command: MessageCommandBuilder;
+    /**
+     * The message that triggered this command.
+     */
+    message: Message;
+    /**
+     * The client instance
+     */
+    client: RecipleClient<true>;
+}
+
+export interface MessageCommandFlagBuilderData<V extends string|boolean = string|boolean, T extends any = V> {
+    name: string;
+    short?: string;
+    description: string;
+    default_values?: V[];
+    required?: boolean;
+    multiple?: boolean;
+    /**
+     * The function that validates the option value.
+     * @param options The option value and message.
+     */
+    validate?: (options: MessageCommandFlagBuilderResolveValueOptions<V, T>) => Awaitable<boolean|string|Error>;
+    /**
+     * Resolves the option value.
+     * @param options The option value and message.
+     */
+    resolve_value?: (options: MessageCommandFlagBuilderResolveValueOptions<V, T>) => Awaitable<T>;
+}
+
+export class MessageCommandFlagBuilder<V extends string|boolean = string|boolean, T extends any = V> implements MessageCommandFlagBuilderData<V, T> {
+    public name: string = '';
+    public short?: string;
+    public description: string = '';
+    public default_values?: V[];
+    public required: boolean = false;
+    public multiple?: boolean = false;
+    public validate?: (options: MessageCommandFlagBuilderResolveValueOptions<V, T>) => Awaitable<boolean|string|Error>;
+    public resolve_value?: (options: MessageCommandFlagBuilderResolveValueOptions<V, T>) => Awaitable<T>;
+
+    constructor(data?: Partial<MessageCommandFlagBuilderData<V, T>>) {
+        if (data?.name) this.setName(data.name);
+        if (data?.short) this.setShort(data.short);
+        if (data?.description) this.setDescription(data.description);
+        if (data?.default_values) this.setDefaultValues(data.default_values);
+        if (data?.required) this.setRequired(data.required);
+        if (data?.multiple) this.setMultiple(data.multiple);
+        if (data?.validate) this.setValidate(data.validate);
+        if (data?.resolve_value) this.setResolveValue(data.resolve_value);
+    }
+
+    public setName(name: string): this {
+        this.name = name;
+        return this;
+    }
+
+    public setShort(short: string): this {
+        this.short = short;
+        return this;
+    }
+
+    public setDescription(description: string): this {
+        this.description = description;
+        return this;
+    }
+
+    public setDefaultValues(...defaultValues: RestOrArray<V>): this {
+        this.default_values = normalizeArray(defaultValues);
+        return this;
+    }
+
+    public setRequired(required: boolean): this {
+        this.required = required;
+        return this;
+    }
+
+    public setMultiple(multiple: boolean): this {
+        this.multiple = multiple;
+        return this;
+    }
+
+    public setValidate(validate: MessageCommandFlagBuilderData<V, T>['validate']): this {
+        this.validate = validate;
+        return this;
+    }
+
+    public setResolveValue(resolve_value: MessageCommandFlagBuilderData<V, T>['resolve_value']): this {
+        this.resolve_value = resolve_value;
+        return this;
+    }
+
+    public toJSON(): MessageCommandFlagBuilderData<V, T> {
+        return {
+            name: this.name,
+            short: this.short,
+            description: this.description,
+            default_values: this.default_values,
+            required: this.required,
+            multiple: this.multiple,
+            validate: this.validate,
+            resolve_value: this.resolve_value
+        };
+    }
+
+    public static from<V extends string|boolean = string|boolean, T extends any = V>(data: MessageCommandFlagResolvable<V, T>): MessageCommandFlagBuilder<V, T> {
+        return new MessageCommandFlagBuilder(isJSONEncodable(data) ? data.toJSON() : data);
+    }
+
+    public static resolve<V extends string|boolean = string|boolean, T extends any = V>(data: MessageCommandFlagResolvable<V, T>): MessageCommandFlagBuilder<V, T> {
+        return data instanceof MessageCommandFlagBuilder ? data : MessageCommandFlagBuilder.from(data);
+    }
+}
+
+export type MessageCommandFlagResolvable<V extends string|boolean = string|boolean, T extends any = V> = JSONEncodable<MessageCommandFlagBuilderData<V, T>>|MessageCommandFlagBuilderData<V, T>;

--- a/packages/core/src/classes/builders/MessageCommandFlagBuilder.ts
+++ b/packages/core/src/classes/builders/MessageCommandFlagBuilder.ts
@@ -16,7 +16,7 @@ export interface MessageCommandFlagBuilderResolveValueOptions<V extends string|b
     /**
      * The flag builder used to build this option.
      */
-    option: MessageCommandFlagBuilder<V, T>;
+    flag: MessageCommandFlagBuilder<V, T>;
     /**
      * The command builder used to build this command.
      */
@@ -37,6 +37,7 @@ export interface MessageCommandFlagBuilderData<V extends string|boolean = string
     description: string;
     default_values?: V[];
     required?: boolean;
+    mandatory?: boolean;
     multiple?: boolean;
     /**
      * The function that validates the option value.
@@ -56,6 +57,7 @@ export class MessageCommandFlagBuilder<V extends string|boolean = string|boolean
     public description: string = '';
     public default_values?: V[];
     public required: boolean = false;
+    public mandatory?: boolean = false;
     public multiple?: boolean = false;
     public validate?: (options: MessageCommandFlagBuilderResolveValueOptions<V, T>) => Awaitable<boolean|string|Error>;
     public resolve_value?: (options: MessageCommandFlagBuilderResolveValueOptions<V, T>) => Awaitable<T[]>;
@@ -66,6 +68,7 @@ export class MessageCommandFlagBuilder<V extends string|boolean = string|boolean
         if (data?.description) this.setDescription(data.description);
         if (data?.default_values) this.setDefaultValues(data.default_values);
         if (data?.required) this.setRequired(data.required);
+        if (data?.mandatory) this.setMandatory(data.mandatory);
         if (data?.multiple) this.setMultiple(data.multiple);
         if (data?.validate) this.setValidate(data.validate);
         if (data?.resolve_value) this.setResolveValue(data.resolve_value);
@@ -99,6 +102,12 @@ export class MessageCommandFlagBuilder<V extends string|boolean = string|boolean
     public setRequired(required: boolean): this {
         MessageCommandFlagValidators.isValidRequired(required);
         this.required = required;
+        return this;
+    }
+
+    public setMandatory(mandatory: boolean): this {
+        MessageCommandFlagValidators.isValidMandatory(mandatory);
+        this.mandatory = mandatory;
         return this;
     }
 

--- a/packages/core/src/classes/builders/MessageCommandFlagBuilder.ts
+++ b/packages/core/src/classes/builders/MessageCommandFlagBuilder.ts
@@ -39,7 +39,7 @@ export interface MessageCommandFlagBuilderData<T extends any = string|boolean> {
     required?: boolean;
     mandatory?: boolean;
     multiple?: boolean;
-    accept?: 'string'|'boolean';
+    value_type?: 'string'|'boolean';
     /**
      * The function that validates the option value.
      * @param options The option value and message.
@@ -60,7 +60,7 @@ export class MessageCommandFlagBuilder<T extends any = string|boolean> implement
     public required: boolean = false;
     public mandatory?: boolean = false;
     public multiple?: boolean = false;
-    public accept?: 'string'|'boolean';
+    public value_type?: 'string'|'boolean' = 'string';
     public validate?: (options: MessageCommandFlagBuilderResolveValueOptions<T>) => Awaitable<boolean|string|Error>;
     public resolve_value?: (options: MessageCommandFlagBuilderResolveValueOptions<T>) => Awaitable<T[]>;
 
@@ -72,6 +72,7 @@ export class MessageCommandFlagBuilder<T extends any = string|boolean> implement
         if (data?.required) this.setRequired(data.required);
         if (data?.mandatory) this.setMandatory(data.mandatory);
         if (data?.multiple) this.setMultiple(data.multiple);
+        if (data?.value_type) this.setValueType(data.value_type);
         if (data?.validate) this.setValidate(data.validate);
         if (data?.resolve_value) this.setResolveValue(data.resolve_value);
     }
@@ -119,9 +120,9 @@ export class MessageCommandFlagBuilder<T extends any = string|boolean> implement
         return this;
     }
 
-    public setAccept(accept: 'string'|'boolean'): this {
-        MessageCommandFlagValidators.isValidAccept(accept);
-        this.accept = accept as any;
+    public setValueType(valueType: 'string'|'boolean'): this {
+        MessageCommandFlagValidators.isValidValueType(valueType);
+        this.value_type = valueType as any;
         return this as any;
     }
 

--- a/packages/core/src/classes/builders/MessageCommandFlagBuilder.ts
+++ b/packages/core/src/classes/builders/MessageCommandFlagBuilder.ts
@@ -2,6 +2,7 @@ import { isJSONEncodable, normalizeArray, type Awaitable, type JSONEncodable, ty
 import type { CommandData } from '../../types/structures.js';
 import type { MessageCommandBuilder } from './MessageCommandBuilder.js';
 import type { RecipleClient } from '../structures/RecipleClient.js';
+import { MessageCommandFlagValidators } from '../validators/MessageCommandFlagValidator.js';
 
 export interface MessageCommandFlagBuilderResolveValueOptions<V extends string|boolean = string|boolean, T extends any = V> {
     /**
@@ -46,7 +47,7 @@ export interface MessageCommandFlagBuilderData<V extends string|boolean = string
      * Resolves the option value.
      * @param options The option value and message.
      */
-    resolve_value?: (options: MessageCommandFlagBuilderResolveValueOptions<V, T>) => Awaitable<T>;
+    resolve_value?: (options: MessageCommandFlagBuilderResolveValueOptions<V, T>) => Awaitable<T[]>;
 }
 
 export class MessageCommandFlagBuilder<V extends string|boolean = string|boolean, T extends any = V> implements MessageCommandFlagBuilderData<V, T> {
@@ -57,7 +58,7 @@ export class MessageCommandFlagBuilder<V extends string|boolean = string|boolean
     public required: boolean = false;
     public multiple?: boolean = false;
     public validate?: (options: MessageCommandFlagBuilderResolveValueOptions<V, T>) => Awaitable<boolean|string|Error>;
-    public resolve_value?: (options: MessageCommandFlagBuilderResolveValueOptions<V, T>) => Awaitable<T>;
+    public resolve_value?: (options: MessageCommandFlagBuilderResolveValueOptions<V, T>) => Awaitable<T[]>;
 
     constructor(data?: Partial<MessageCommandFlagBuilderData<V, T>>) {
         if (data?.name) this.setName(data.name);
@@ -71,41 +72,50 @@ export class MessageCommandFlagBuilder<V extends string|boolean = string|boolean
     }
 
     public setName(name: string): this {
+        MessageCommandFlagValidators.isValidName(name);
         this.name = name;
         return this;
     }
 
     public setShort(short: string): this {
+        MessageCommandFlagValidators.isValidShort(short);
         this.short = short;
         return this;
     }
 
     public setDescription(description: string): this {
+        MessageCommandFlagValidators.isValidDescription(description);
         this.description = description;
         return this;
     }
 
     public setDefaultValues(...defaultValues: RestOrArray<V>): this {
-        this.default_values = normalizeArray(defaultValues);
+        defaultValues = normalizeArray(defaultValues);
+        MessageCommandFlagValidators.isValidDefaultValues(defaultValues);
+        this.default_values = defaultValues;
         return this;
     }
 
     public setRequired(required: boolean): this {
+        MessageCommandFlagValidators.isValidRequired(required);
         this.required = required;
         return this;
     }
 
     public setMultiple(multiple: boolean): this {
+        MessageCommandFlagValidators.isValidMultiple(multiple);
         this.multiple = multiple;
         return this;
     }
 
     public setValidate(validate: MessageCommandFlagBuilderData<V, T>['validate']): this {
+        MessageCommandFlagValidators.isValidValidate(validate);
         this.validate = validate;
         return this;
     }
 
     public setResolveValue(resolve_value: MessageCommandFlagBuilderData<V, T>['resolve_value']): this {
+        MessageCommandFlagValidators.isValidResolveValue(resolve_value);
         this.resolve_value = resolve_value;
         return this;
     }
@@ -121,6 +131,11 @@ export class MessageCommandFlagBuilder<V extends string|boolean = string|boolean
             validate: this.validate,
             resolve_value: this.resolve_value
         };
+    }
+
+    public static getFlagValuesType(values: (string|boolean)[]): 'string'|'boolean' {
+        const type = typeof values[0];
+        return type === 'string' || type === 'boolean' ? type : 'string';
     }
 
     public static from<V extends string|boolean = string|boolean, T extends any = V>(data: MessageCommandFlagResolvable<V, T>): MessageCommandFlagBuilder<V, T> {

--- a/packages/core/src/classes/builders/MessageCommandOptionBuilder.ts
+++ b/packages/core/src/classes/builders/MessageCommandOptionBuilder.ts
@@ -137,7 +137,7 @@ export class MessageCommandOptionBuilder<T extends any = any> implements Message
     }
 
     public static resolve<T extends any = any>(data: MessageCommandOptionResolvable<T>): MessageCommandOptionBuilder<T> {
-        return data instanceof MessageCommandOptionBuilder ? data : this.from(data);
+        return data instanceof MessageCommandOptionBuilder ? data : MessageCommandOptionBuilder.from(data);
     }
 }
 

--- a/packages/core/src/classes/builders/SlashCommandBuilder.ts
+++ b/packages/core/src/classes/builders/SlashCommandBuilder.ts
@@ -213,7 +213,7 @@ export class SlashCommandBuilder extends Mixin(DiscordJsSlashCommandBuilder, Bas
     }
 
     public static resolve(data: SlashCommandResolvable): AnySlashCommandBuilder {
-        return data instanceof SlashCommandBuilder ? data : this.from(data);
+        return data instanceof SlashCommandBuilder ? data : SlashCommandBuilder.from(data);
     }
 
     public static async execute({ client, interaction, command }: SlashCommandExecuteOptions): Promise<SlashCommandExecuteData|null> {

--- a/packages/core/src/classes/managers/MessageCommandFlagManager.ts
+++ b/packages/core/src/classes/managers/MessageCommandFlagManager.ts
@@ -56,10 +56,10 @@ export class MessageCommandFlagManager extends DataManager<MessageCommandFlagVal
      * @param {boolean} required - Whether the flag is required or not.
      * @return {MessageCommandOptionValue<V>|null} The value of the message command flag.
      */
-    public getFlag<V extends string|boolean = string|boolean, T extends any = any>(name: string, required: true): MessageCommandFlagValue<V, T>;
-    public getFlag<V extends string|boolean = string|boolean, T extends any = any>(name: string, required?: boolean): MessageCommandFlagValue<V, T>|null;
-    public getFlag<V extends string|boolean = string|boolean, T extends any = any>(name: string, required: boolean = false): MessageCommandFlagValue<V, T>|null {
-        const flag = this.cache.get(name) as MessageCommandFlagValue<V, T>|undefined;
+    public getFlag<T extends any = string|boolean>(name: string, required: true): MessageCommandFlagValue<T>;
+    public getFlag<T extends any = string|boolean>(name: string, required?: boolean): MessageCommandFlagValue<T>|null;
+    public getFlag<T extends any = string|boolean>(name: string, required: boolean = false): MessageCommandFlagValue<T>|null {
+        const flag = this.cache.get(name) as MessageCommandFlagValue<T>|undefined;
         if (required && !flag) throw new RecipleError(`Unable to find required message flag '${name}'`);
 
         return flag ?? null;
@@ -72,11 +72,11 @@ export class MessageCommandFlagManager extends DataManager<MessageCommandFlagVal
      * @param options.required Whether the flag is required or not.
      * @param options.resolveValue Whether to resolve the value or not.
      */
-    public getFlagValues<V extends string|boolean = string|boolean, T extends any = any>(name: string, options?: { required?: boolean; resolveValue?: false; }): V[];
-    public getFlagValues<V extends string|boolean = string|boolean, T extends any = any>(name: string, options?: { required?: boolean; resolveValue?: true; }): Promise<T[]>;
-    public getFlagValues<V extends string|boolean = string|boolean, T extends any = any>(name: string, options?: { required?: boolean; resolveValue?: boolean; }): Promise<T[]>|V[];
-    public getFlagValues<V extends string|boolean = string|boolean, T extends any = any>(name: string, options: { required?: boolean; resolveValue?: boolean; } = { required: false, resolveValue: false }): Promise<T[]>|V[] {
-        const value = this.getFlag<V>(name, options.required);
+    public getFlagValues<T extends any = string|boolean>(name: string, options?: { required?: boolean; resolveValue?: false; }): string[]|boolean[];
+    public getFlagValues<T extends any = string|boolean>(name: string, options?: { required?: boolean; resolveValue?: true; }): Promise<T[]>;
+    public getFlagValues<T extends any = string|boolean>(name: string, options?: { required?: boolean; resolveValue?: boolean; }): Promise<T[]>|string[]|boolean[];
+    public getFlagValues<T extends any = string|boolean>(name: string, options: { required?: boolean; resolveValue?: boolean; } = { required: false, resolveValue: false }): Promise<T[]>|string[]|boolean[] {
+        const value = this.getFlag<T>(name, options.required);
         return options.resolveValue
             ? Promise.resolve(value?.resolveValues()).then(v => v ?? [])
             : value?.values ?? [];

--- a/packages/core/src/classes/managers/MessageCommandFlagManager.ts
+++ b/packages/core/src/classes/managers/MessageCommandFlagManager.ts
@@ -72,10 +72,10 @@ export class MessageCommandFlagManager extends DataManager<MessageCommandFlagVal
      * @param options.required Whether the flag is required or not.
      * @param options.resolveValue Whether to resolve the value or not.
      */
-    public getFlagValues<T extends any = string|boolean>(name: string, options?: { required?: boolean; resolveValue?: false; }): string[]|boolean[];
+    public getFlagValues<T extends any = string|boolean, V extends 'string'|'boolean' = 'string'|'boolean'>(name: string, options?: { required?: boolean; resolveValue?: false; type?: V }): V extends 'string' ? string[] : V extends 'boolean' ? boolean[] : string[]|boolean[];
     public getFlagValues<T extends any = string|boolean>(name: string, options?: { required?: boolean; resolveValue?: true; }): Promise<T[]>;
-    public getFlagValues<T extends any = string|boolean>(name: string, options?: { required?: boolean; resolveValue?: boolean; }): Promise<T[]>|string[]|boolean[];
-    public getFlagValues<T extends any = string|boolean>(name: string, options: { required?: boolean; resolveValue?: boolean; } = { required: false, resolveValue: false }): Promise<T[]>|string[]|boolean[] {
+    public getFlagValues<T extends any = string|boolean, V extends 'string'|'boolean' = 'string'|'boolean'>(name: string, options?: { required?: boolean; resolveValue?: boolean; type?: V }): Promise<T[]>|(V extends 'string' ? string[] : V extends 'boolean' ? boolean[] : string[]|boolean[]);
+    public getFlagValues<T extends any = string|boolean>(name: string, options: { required?: boolean; resolveValue?: boolean; type?: 'string'|'boolean' } = { required: false, resolveValue: false }): Promise<T[]>|string[]|boolean[] {
         const value = this.getFlag<T>(name, options.required);
         return options.resolveValue
             ? Promise.resolve(value?.resolveValues()).then(v => v ?? [])

--- a/packages/core/src/classes/managers/MessageCommandFlagManager.ts
+++ b/packages/core/src/classes/managers/MessageCommandFlagManager.ts
@@ -1,0 +1,77 @@
+import type { Message } from 'discord.js';
+import type { MessageCommandBuilder } from '../builders/MessageCommandBuilder.js';
+import type { MessageCommandFlagValue } from '../structures/MessageCommandFlagValue.js';
+import type { RecipleClient } from '../structures/RecipleClient.js';
+import { DataManager } from './DataManager.js';
+import type { MessageCommandOptionManagerOptions } from './MessageCommandOptionManager.js';
+import type { CommandData } from '../../types/structures.js';
+import { RecipleError } from '../structures/RecipleError.js';
+
+export class MessageCommandFlagManager extends DataManager<MessageCommandFlagValue> implements MessageCommandOptionManagerOptions {
+    readonly command: MessageCommandBuilder;
+    readonly client: RecipleClient<true>;
+    readonly message: Message;
+    readonly parserData: CommandData;
+
+    constructor(data: MessageCommandOptionManagerOptions) {
+        super();
+
+        this.command = data.command;
+        this.client = data.client;
+        this.message = data.message;
+        this.parserData = data.parserData;
+    }
+
+    get hasMissingFlags() {
+        return this.cache.some(o => o.missing);
+    }
+
+    get hasInvalidFlags() {
+        return this.cache.some(o => o.invalid);
+    }
+
+    get hasValidationErrors() {
+        return this.cache.some(o => o.error);
+    }
+
+    get missingFlags() {
+        return this.cache.filter(o => o.missing);
+    }
+
+    get invalidFlags() {
+        return this.cache.filter(o => o.invalid);
+    }
+
+    /**
+     * Retrieves the value of a message command flag.
+     *
+     * @param {string} name - The name of the flag.
+     * @param {boolean} required - Whether the flag is required or not.
+     * @return {MessageCommandOptionValue<V>|null} The value of the message command flag.
+     */
+    public getFlag<V extends string|boolean = string|boolean, T extends any = any>(name: string, required: true): MessageCommandFlagValue<V, T>;
+    public getFlag<V extends string|boolean = string|boolean, T extends any = any>(name: string, required?: boolean): MessageCommandFlagValue<V, T>|null;
+    public getFlag<V extends string|boolean = string|boolean, T extends any = any>(name: string, required: boolean = false): MessageCommandFlagValue<V, T>|null {
+        const flag = this.cache.get(name) as MessageCommandFlagValue<V, T>|undefined;
+        if (required && !flag) throw new RecipleError(`Unable to find required message flag '${name}'`);
+
+        return flag ?? null;
+    }
+
+    /**
+     * Obtains the value of a message command flag.
+     * @param name The name of the flag.
+     * @param options The flags to use when parsing the flag value.
+     * @param options.required Whether the flag is required or not.
+     * @param options.resolveValue Whether to resolve the value or not.
+     */
+    public getFlagValues<V extends string|boolean = string|boolean, T extends any = any>(name: string, options?: { required?: boolean; resolveValue?: false; }): V[];
+    public getFlagValues<V extends string|boolean = string|boolean, T extends any = any>(name: string, options?: { required?: boolean; resolveValue?: true; }): Promise<T[]>;
+    public getFlagValues<V extends string|boolean = string|boolean, T extends any = any>(name: string, options?: { required?: boolean; resolveValue?: boolean; }): Promise<T[]>|V[];
+    public getFlagValues<V extends string|boolean = string|boolean, T extends any = any>(name: string, options: { required?: boolean; resolveValue?: boolean; } = { required: false, resolveValue: false }): Promise<T[]>|V[] {
+        const value = this.getFlag<V>(name, options.required);
+        return options.resolveValue
+            ? Promise.resolve(value?.resolveValues()).then(v => v ?? [])
+            : value?.values ?? [];
+    }
+}

--- a/packages/core/src/classes/managers/MessageCommandOptionManager.ts
+++ b/packages/core/src/classes/managers/MessageCommandOptionManager.ts
@@ -95,8 +95,8 @@ export class MessageCommandOptionManager extends DataManager<MessageCommandOptio
      * @param {boolean} required - Whether the option is required or not.
      * @return {MessageCommandOptionValue<V>|null} The value of the message command option.
      */
-    public getOption<V extends any = any>(name: string, required?: false): MessageCommandOptionValue<V>;
-    public getOption<V extends any = any>(name: string, required?: true): MessageCommandOptionValue<V>;
+    public getOption<V extends any = any>(name: string, required: true): MessageCommandOptionValue<V>;
+    public getOption<V extends any = any>(name: string, required?: boolean): MessageCommandOptionValue<V>|null;
     public getOption<V extends any = any>(name: string, required: boolean = false): MessageCommandOptionValue<V>|null {
         const option = this.cache.get(name);
         if (required && !option) throw new RecipleError(`Unable to find required message option '${name}'`);
@@ -113,11 +113,21 @@ export class MessageCommandOptionManager extends DataManager<MessageCommandOptio
      */
     public getOptionValue<V extends any = any>(name: string, options?: { required?: false; resolveValue?: false; }): string|null;
     public getOptionValue<V extends any = any>(name: string, options?: { required?: true; resolveValue?: false; }): string;
-    public getOptionValue<V extends any = any>(name: string, options?: { required?: true; resolveValue?: true; }): Promise<V>;
+    public getOptionValue<V extends any = any>(name: string, options?: { required?: boolean; resolveValue?: false; }): string|null;
     public getOptionValue<V extends any = any>(name: string, options?: { required?: false; resolveValue?: true; }): Promise<V|null>;
+    public getOptionValue<V extends any = any>(name: string, options?: { required?: true; resolveValue?: true; }): Promise<V>;
+    public getOptionValue<V extends any = any>(name: string, options?: { required?: boolean; resolveValue?: true; }): Promise<V|null>;
+    public getOptionValue<V extends any = any>(name: string, options?: { required?: boolean; resolveValue?: boolean; }): string|null|Promise<V|null>;
     public getOptionValue<V extends any = any>(name: string, options: { required?: boolean; resolveValue?: boolean; } = { required: false, resolveValue: false }): string|null|Promise<V|null> {
-        const value = this.getOption<V>(name);
-        return options.resolveValue ? Promise.resolve(value.resolveValue(options.required) ?? value.value) : value.value;
+        const value = this.getOption<V>(name, options.required);
+
+        if (options.resolveValue) {
+            if (!value) return Promise.resolve(null);
+
+            return value.resolveValue(options.required) ?? null;
+        }
+
+        return value?.value ?? null;
     }
 
     public toJSON() {

--- a/packages/core/src/classes/structures/CommandHalt.ts
+++ b/packages/core/src/classes/structures/CommandHalt.ts
@@ -126,7 +126,7 @@ export class CommandHalt implements CommandHaltData {
     }
 
     public static resolve(data: CommandHaltResolvable): CommandHalt {
-        return data instanceof CommandHalt ? data : this.from(data);
+        return data instanceof CommandHalt ? data : CommandHalt.from(data);
     }
 }
 

--- a/packages/core/src/classes/structures/CommandPrecondition.ts
+++ b/packages/core/src/classes/structures/CommandPrecondition.ts
@@ -111,7 +111,7 @@ export class CommandPrecondition implements CommandPreconditionData {
     }
 
     public static resolve(data: CommandPreconditionResolvable): CommandPrecondition {
-        return data instanceof CommandPrecondition ? data : this.from(data);
+        return data instanceof CommandPrecondition ? data : CommandPrecondition.from(data);
     }
 }
 

--- a/packages/core/src/classes/structures/MessageCommandFlagValue.ts
+++ b/packages/core/src/classes/structures/MessageCommandFlagValue.ts
@@ -5,7 +5,7 @@ import type { MessageCommandFlagBuilder, MessageCommandFlagBuilderResolveValueOp
 import type { RecipleClient } from './RecipleClient.js';
 import { RecipleError } from './RecipleError.js';
 
-export interface MessageCommandFlagValueData<T extends any = string|boolean> {
+export interface MessageCommandFlagValueData<T extends any = string|boolean, V extends 'string'|'boolean' = 'string'|'boolean'> {
     /**
      * The name of the option.
      */
@@ -17,7 +17,7 @@ export interface MessageCommandFlagValueData<T extends any = string|boolean> {
     /**
      * The raw value of the option.
      */
-    values: string[]|boolean[];
+    values: V extends 'boolean' ? boolean[] : V extends 'string' ? string[] : string[]|boolean[];
     /**
      * Whether the option is missing.
      */
@@ -36,15 +36,15 @@ export interface MessageCommandFlagParseOptionValueOptions<T extends any = strin
     values?: T[]|null;
 }
 
-export interface MessageCommandFlagValueOptions<T extends any = string|boolean> extends MessageCommandFlagValueData<T>, Pick<MessageCommandFlagParseOptionValueOptions<T>, 'parserData'|'command'> {
+export interface MessageCommandFlagValueOptions<T extends any = string|boolean, V extends 'string'|'boolean' = 'string'|'boolean'> extends MessageCommandFlagValueData<T, V>, Pick<MessageCommandFlagParseOptionValueOptions<T>, 'parserData'|'command'> {
     client: RecipleClient<true>;
     message: Message;
 }
 
-export class MessageCommandFlagValue<T extends any = string|boolean> implements MessageCommandFlagValueData<T> {
+export class MessageCommandFlagValue<T extends any = string|boolean, V extends 'string'|'boolean' = 'string'|'boolean'> implements MessageCommandFlagValueData<T> {
     readonly name: string;
     readonly flag: MessageCommandFlagBuilder<T>;
-    readonly values: string[]|boolean[];
+    readonly values: V extends 'boolean' ? boolean[] : V extends 'string' ? string[] : string[]|boolean[];
     readonly missing: boolean;
     readonly invalid: boolean;
     readonly message: Message;
@@ -54,7 +54,7 @@ export class MessageCommandFlagValue<T extends any = string|boolean> implements 
     readonly command: MessageCommandBuilder;
     readonly client: RecipleClient<true>;
 
-    constructor(options: MessageCommandFlagValueOptions<T>) {
+    constructor(options: MessageCommandFlagValueOptions<T, V>) {
         this.name = options.name;
         this.flag = options.flag;
         this.values = options.values;
@@ -98,7 +98,7 @@ export class MessageCommandFlagValue<T extends any = string|boolean> implements 
     }
 
     public static async parseFlagValue<T extends any = string|boolean>(options: MessageCommandFlagParseOptionValueOptions<T>): Promise<MessageCommandFlagValue<T>> {
-        const filteredValues = options.values?.filter(value => typeof value == options.flag.accept);
+        const filteredValues = options.values?.filter(value => typeof value == options.flag.value_type);
         const missing = filteredValues
             ? !!options.flag.required && !filteredValues?.length
             : options.flag.mandatory ?? false;

--- a/packages/core/src/classes/structures/MessageCommandFlagValue.ts
+++ b/packages/core/src/classes/structures/MessageCommandFlagValue.ts
@@ -1,0 +1,129 @@
+import type { Message } from 'discord.js';
+import type { CommandData } from '../../types/structures.js';
+import type { MessageCommandBuilder } from '../builders/MessageCommandBuilder.js';
+import type { MessageCommandFlagBuilder, MessageCommandFlagBuilderResolveValueOptions } from '../builders/MessageCommandFlagBuilder.js';
+import type { RecipleClient } from './RecipleClient.js';
+
+export interface MessageCommandFlagValueData<V extends string|boolean = string|boolean, T extends any = V> {
+    /**
+     * The name of the option.
+     */
+    name: string;
+    /**
+     * The builder that is used to create the option.
+     */
+    option: MessageCommandFlagBuilder<V, T>;
+    /**
+     * The raw value of the option.
+     */
+    values: V[];
+    /**
+     * Whether the option is missing.
+     */
+    missing: boolean;
+    /**
+     * Whether the option is invalid.
+     */
+    invalid: boolean;
+    /**
+     * The error that occurred while parsing the option.
+     */
+    error?: string|Error;
+}
+
+export interface MessageCommandFlagParseOptionValueOptions<V extends string|boolean = string|boolean, T extends any = V> extends Omit<MessageCommandFlagBuilderResolveValueOptions<V, T>, 'values'> {
+    values?: V[]|null;
+}
+
+export interface MessageCommandFlagValueOptions<V extends string|boolean = string|boolean, T extends any = V> extends MessageCommandFlagValueData<V, T>, Pick<MessageCommandFlagParseOptionValueOptions<V, T>, 'parserData'|'command'> {
+    client: RecipleClient<true>;
+    message: Message;
+}
+
+export class MessageCommandFlagValue<V extends string|boolean = string|boolean, T extends any = V> implements MessageCommandFlagValueData<V, T> {
+    readonly name: string;
+    readonly option: MessageCommandFlagBuilder<V, T>;
+    readonly values: V[];
+    readonly missing: boolean;
+    readonly invalid: boolean;
+    readonly message: Message;
+    readonly error?: Error;
+
+    readonly parserData: CommandData;
+    readonly command: MessageCommandBuilder;
+    readonly client: RecipleClient<true>;
+
+    constructor(options: MessageCommandFlagValueOptions<V, T>) {
+        this.name = options.name;
+        this.option = options.option;
+        this.values = options.values;
+        this.missing = options.missing;
+        this.invalid = options.invalid;
+        this.message = options.message;
+        this.error = typeof options.error === 'string' ? new Error(options.error) : options.error;
+        this.parserData = options.parserData;
+        this.command = options.command;
+        this.client = options.client;
+    }
+
+    /**
+     * Resolves the raw value of the option.
+     * @param required Whether the option is required.
+     */
+    public async resolveValues(): Promise<T[]> {
+        if (this.values.length) return [];
+
+        return this.option.resolve_value
+            ? Promise.resolve(this.option.resolve_value({
+                values: this.values,
+                option: this.option,
+                parserData: this.parserData,
+                command: this.command,
+                message: this.message,
+                client: this.client,
+            }))
+            : [];
+    }
+
+    public toJSON(): MessageCommandFlagValueData<V, T> {
+        return {
+            name: this.name,
+            option: this.option,
+            values: this.values,
+            missing: this.missing,
+            invalid: this.invalid,
+            error: this.error,
+        }
+    }
+
+    public static async parseFlagValue<V extends string|boolean = string|boolean, T extends any = V>(options: MessageCommandFlagParseOptionValueOptions<V, T>): Promise<MessageCommandFlagValue<V, T>> {
+        const missing = !!options.option.required && !options.values?.length;
+        const validateData = !missing
+            ? options.option.validate && options.values?.length
+                ? await Promise.resolve(options.option.validate({
+                    values: options.values,
+                    option: options.option,
+                    parserData: options.parserData,
+                    command: options.command,
+                    message: options.message,
+                    client: options.client,
+                }))
+                : true
+            : false;
+
+        return new MessageCommandFlagValue({
+            name: options.option.name,
+            option: options.option,
+            values: options.values ?? [],
+            missing,
+            invalid: !validateData,
+            message: options.message,
+            error: typeof validateData !== 'boolean'
+                ? typeof validateData === 'string' ? new Error(validateData) : validateData
+                : undefined,
+            parserData: options.parserData,
+            command: options.command,
+            client: options.client,
+        })
+    }
+}

--- a/packages/core/src/classes/structures/MessageCommandOptionValue.ts
+++ b/packages/core/src/classes/structures/MessageCommandOptionValue.ts
@@ -3,6 +3,7 @@ import { MessageCommandBuilder } from '../builders/MessageCommandBuilder.js';
 import type { CommandData } from '../../types/structures.js';
 import { RecipleClient } from './RecipleClient.js';
 import { Message } from 'discord.js';
+import { RecipleError } from './RecipleError.js';
 
 export interface MessageCommandOptionValueData<T extends any = any> {
     /**
@@ -107,7 +108,7 @@ export class MessageCommandOptionValue<T extends any = any> implements MessageCo
                     client: options.client,
                 }))
                 : true
-            : false;
+            : new RecipleError(RecipleError.createCommandRequiredOptionNotFoundErrorOptions(options.option.name, options.value));
 
         return new MessageCommandOptionValue({
             name: options.option.name,

--- a/packages/core/src/classes/structures/RecipleError.ts
+++ b/packages/core/src/classes/structures/RecipleError.ts
@@ -60,7 +60,23 @@ export class RecipleError extends Error {
 
     public static createCommandRequiredOptionNotFoundErrorOptions(optionName: string, value: unknown): RecipleErrorOptions {
         return {
-            message: `No value given from required option ${kleur.cyan("'" + optionName + "'")}`,
+            message: `No value given for required option ${kleur.cyan("'" + optionName + "'")}`,
+            cause: { value },
+            name: 'RequiredOptionNotFound'
+        };
+    }
+
+    public static createCommandRequiredFlagNotFoundErrorOptions(flagName: string, value: unknown): RecipleErrorOptions {
+        return {
+            message: `No value given for required flag ${kleur.cyan("'" + flagName + "'")}`,
+            cause: { value },
+            name: 'RequiredOptionNotFound'
+        };
+    }
+
+    public static createCommandMandatoryFlagNotFoundErrorOptions(flagName: string, value: unknown): RecipleErrorOptions {
+        return {
+            message: `No value given for mandatory flag ${kleur.cyan("'" + flagName + "'")}`,
             cause: { value },
             name: 'RequiredOptionNotFound'
         };

--- a/packages/core/src/classes/structures/RecipleError.ts
+++ b/packages/core/src/classes/structures/RecipleError.ts
@@ -70,7 +70,7 @@ export class RecipleError extends Error {
         return {
             message: `No value given for required flag ${kleur.cyan("'" + flagName + "'")}`,
             cause: { value },
-            name: 'RequiredOptionNotFound'
+            name: 'RequiredFlagNotFound'
         };
     }
 
@@ -78,7 +78,7 @@ export class RecipleError extends Error {
         return {
             message: `No value given for mandatory flag ${kleur.cyan("'" + flagName + "'")}`,
             cause: { value },
-            name: 'RequiredOptionNotFound'
+            name: 'MandatoryFlagNotFound'
         };
     }
 

--- a/packages/core/src/classes/validators/MessageCommandFlagValidator.ts
+++ b/packages/core/src/classes/validators/MessageCommandFlagValidator.ts
@@ -1,0 +1,114 @@
+import type { MessageCommandFlagBuilderData, MessageCommandFlagResolvable } from '../builders/MessageCommandFlagBuilder.js';
+import { BaseCommandValidators } from './BaseCommandValidators.js';
+import { isJSONEncodable } from 'discord.js';
+
+export class MessageCommandFlagValidators extends BaseCommandValidators {
+    public static name = MessageCommandFlagValidators.s
+        .string({ message: 'Expected string as message command flag name' })
+        .lengthGreaterThanOrEqual(1, { message: 'Message command flag name needs to have at least single character' })
+        .lengthLessThanOrEqual(32, { message: 'Message command flag name cannot exceed 32 characters' })
+        .regex(/^[\p{Ll}\p{Lm}\p{Lo}\p{N}\p{sc=Devanagari}\p{sc=Thai}_-]+$/u, { message: 'Message command flag name can only be alphanumeric without spaces' });
+
+    public static short = MessageCommandFlagValidators.s
+        .string({ message: 'Expected string as message command flag short' })
+        .lengthEqual(1, { message: 'Message command flag short needs to have at least single character' })
+        .optional();
+
+    public static description = MessageCommandFlagValidators.s
+        .string({ message: 'Expected string as message command flag description' })
+        .lengthGreaterThanOrEqual(1, { message: 'Message command flag description needs to have at least single character' })
+        .lengthLessThanOrEqual(100, { message: 'Message command flag description cannot exceed 100 characters' });
+
+    public static default_values = MessageCommandFlagValidators.s
+        .union([
+            MessageCommandFlagValidators.s.string({ message: 'Expected string as message command flag default value' }),
+            MessageCommandFlagValidators.s.boolean({ message: 'Expected boolean as message command flag default value' }),
+        ])
+        .array({ message: 'Expected array as message command flag default values' })
+        .optional();
+
+    public static required = MessageCommandFlagValidators.s
+        .boolean({ message: 'Expected boolean for .required' })
+        .optional();
+
+    public static multiple = MessageCommandFlagValidators.s
+        .boolean({ message: 'Expected boolean for .multiple' })
+        .optional();
+
+    public static validate = MessageCommandFlagValidators.s
+        .instance(Function, { message: 'Expected a function for .validate' })
+        .optional();
+
+    public static resolve_value = MessageCommandFlagValidators.s
+        .instance(Function, { message: 'Expected a function for .resolve_value' })
+        .optional();
+
+    public static MessageCommandFlagBuilderData = MessageCommandFlagValidators.s.object({
+        name: MessageCommandFlagValidators.name,
+        short: MessageCommandFlagValidators.short,
+        description: MessageCommandFlagValidators.description,
+        default_values: MessageCommandFlagValidators.default_values,
+        required: MessageCommandFlagValidators.required,
+        multiple: MessageCommandFlagValidators.multiple,
+        validate: MessageCommandFlagValidators.validate,
+        resolve_value: MessageCommandFlagValidators.resolve_value
+    });
+
+    public static MessageCommandFlagResolvable = MessageCommandFlagValidators.s.union([MessageCommandFlagValidators.MessageCommandFlagBuilderData, MessageCommandFlagValidators.jsonEncodable]);
+
+    public static isValidName(name: unknown): asserts name is MessageCommandFlagBuilderData['name'] {
+        MessageCommandFlagValidators.name.setValidationEnabled(MessageCommandFlagValidators.isValidationEnabled).parse(name);
+    }
+
+    public static isValidShort(short: unknown): asserts short is MessageCommandFlagBuilderData['short'] {
+        MessageCommandFlagValidators.short.setValidationEnabled(MessageCommandFlagValidators.isValidationEnabled).parse(short);
+    }
+
+    public static isValidDescription(description: unknown): asserts description is MessageCommandFlagBuilderData['description'] {
+        MessageCommandFlagValidators.description.setValidationEnabled(MessageCommandFlagValidators.isValidationEnabled).parse(description);
+    }
+
+    public static isValidDefaultValues(defaultValues: unknown): asserts defaultValues is MessageCommandFlagBuilderData['default_values'] {
+        MessageCommandFlagValidators.default_values.setValidationEnabled(MessageCommandFlagValidators.isValidationEnabled).parse(defaultValues);
+    }
+
+    public static isValidRequired(required: unknown): asserts required is MessageCommandFlagBuilderData['required'] {
+        MessageCommandFlagValidators.required.setValidationEnabled(MessageCommandFlagValidators.isValidationEnabled).parse(required);
+    }
+
+    public static isValidMultiple(multiple: unknown): asserts multiple is MessageCommandFlagBuilderData['multiple'] {
+        MessageCommandFlagValidators.multiple.setValidationEnabled(MessageCommandFlagValidators.isValidationEnabled).parse(multiple);
+    }
+
+    public static isValidValidate(validate: unknown): asserts validate is MessageCommandFlagBuilderData['validate'] {
+        MessageCommandFlagValidators.validate.setValidationEnabled(MessageCommandFlagValidators.isValidationEnabled).parse(validate);
+    }
+
+    public static isValidResolveValue(resolveValue: unknown): asserts resolveValue is MessageCommandFlagBuilderData['resolve_value'] {
+        MessageCommandFlagValidators.resolve_value.setValidationEnabled(MessageCommandFlagValidators.isValidationEnabled).parse(resolveValue);
+    }
+
+    public static isValidMessageCommandFlagBuilderData(data: unknown): asserts data is MessageCommandFlagBuilderData {
+        const opt = data as MessageCommandFlagBuilderData;
+
+        MessageCommandFlagValidators.isValidName(opt.name);
+        MessageCommandFlagValidators.isValidShort(opt.short);
+        MessageCommandFlagValidators.isValidDescription(opt.description);
+        MessageCommandFlagValidators.isValidDefaultValues(opt.default_values);
+        MessageCommandFlagValidators.isValidRequired(opt.required);
+        MessageCommandFlagValidators.isValidMultiple(opt.multiple);
+        MessageCommandFlagValidators.isValidValidate(opt.validate);
+        MessageCommandFlagValidators.isValidResolveValue(opt.resolve_value);
+    }
+
+    public static isValidMessageCommandFlagResolvable(data: unknown): asserts data is MessageCommandFlagResolvable {
+        const opt = data as MessageCommandFlagResolvable;
+
+        if (isJSONEncodable(opt)) {
+            const i = opt.toJSON();
+            MessageCommandFlagValidators.isValidMessageCommandFlagBuilderData(i);
+        } else {
+            MessageCommandFlagValidators.isValidMessageCommandFlagBuilderData(opt);
+        }
+    }
+}

--- a/packages/core/src/classes/validators/MessageCommandFlagValidator.ts
+++ b/packages/core/src/classes/validators/MessageCommandFlagValidator.ts
@@ -34,6 +34,10 @@ export class MessageCommandFlagValidators extends BaseCommandValidators {
         .boolean({ message: 'Expected boolean for .required' })
         .optional();
 
+    public static mandatory = MessageCommandFlagValidators.s
+        .boolean({ message: 'Expected boolean for .mandatory' })
+        .optional();
+
     public static multiple = MessageCommandFlagValidators.s
         .boolean({ message: 'Expected boolean for .multiple' })
         .optional();
@@ -79,6 +83,10 @@ export class MessageCommandFlagValidators extends BaseCommandValidators {
         MessageCommandFlagValidators.required.setValidationEnabled(MessageCommandFlagValidators.isValidationEnabled).parse(required);
     }
 
+    public static isValidMandatory(mandatory: unknown): asserts mandatory is MessageCommandFlagBuilderData['mandatory'] {
+        MessageCommandFlagValidators.mandatory.setValidationEnabled(MessageCommandFlagValidators.isValidationEnabled).parse(mandatory);
+    }
+
     public static isValidMultiple(multiple: unknown): asserts multiple is MessageCommandFlagBuilderData['multiple'] {
         MessageCommandFlagValidators.multiple.setValidationEnabled(MessageCommandFlagValidators.isValidationEnabled).parse(multiple);
     }
@@ -99,6 +107,7 @@ export class MessageCommandFlagValidators extends BaseCommandValidators {
         MessageCommandFlagValidators.isValidDescription(opt.description);
         MessageCommandFlagValidators.isValidDefaultValues(opt.default_values);
         MessageCommandFlagValidators.isValidRequired(opt.required);
+        MessageCommandFlagValidators.isValidMandatory(opt.mandatory);
         MessageCommandFlagValidators.isValidMultiple(opt.multiple);
         MessageCommandFlagValidators.isValidValidate(opt.validate);
         MessageCommandFlagValidators.isValidResolveValue(opt.resolve_value);

--- a/packages/core/src/classes/validators/MessageCommandFlagValidator.ts
+++ b/packages/core/src/classes/validators/MessageCommandFlagValidator.ts
@@ -42,13 +42,13 @@ export class MessageCommandFlagValidators extends BaseCommandValidators {
         .boolean({ message: 'Expected boolean for .multiple' })
         .optional();
 
-    public static accept = MessageCommandFlagValidators.s
+    public static value_type = MessageCommandFlagValidators.s
         .union([
             MessageCommandFlagValidators.s
-                .literal('string', { equalsOptions: { message: 'Expected "string" for .accept' } })
+                .literal('string', { equalsOptions: { message: 'Expected "string" for .value_type' } })
                 .optional(),
             MessageCommandFlagValidators.s
-                .literal('boolean', { equalsOptions: { message: 'Expected "boolean" for .accept' } })
+                .literal('boolean', { equalsOptions: { message: 'Expected "boolean" for .value_type' } })
                 .optional(),
         ])
         .optional();
@@ -102,8 +102,8 @@ export class MessageCommandFlagValidators extends BaseCommandValidators {
         MessageCommandFlagValidators.multiple.setValidationEnabled(MessageCommandFlagValidators.isValidationEnabled).parse(multiple);
     }
 
-    public static isValidAccept(accept: unknown): asserts accept is MessageCommandFlagBuilderData['accept'] {
-        MessageCommandFlagValidators.accept.setValidationEnabled(MessageCommandFlagValidators.isValidationEnabled).parse(accept);
+    public static isValidValueType(valueType: unknown): asserts valueType is MessageCommandFlagBuilderData['value_type'] {
+        MessageCommandFlagValidators.value_type.setValidationEnabled(MessageCommandFlagValidators.isValidationEnabled).parse(valueType);
     }
 
     public static isValidValidate(validate: unknown): asserts validate is MessageCommandFlagBuilderData['validate'] {
@@ -124,7 +124,7 @@ export class MessageCommandFlagValidators extends BaseCommandValidators {
         MessageCommandFlagValidators.isValidRequired(opt.required);
         MessageCommandFlagValidators.isValidMandatory(opt.mandatory);
         MessageCommandFlagValidators.isValidMultiple(opt.multiple);
-        MessageCommandFlagValidators.isValidAccept(opt.accept);
+        MessageCommandFlagValidators.isValidValueType(opt.value_type);
         MessageCommandFlagValidators.isValidValidate(opt.validate);
         MessageCommandFlagValidators.isValidResolveValue(opt.resolve_value);
     }

--- a/packages/core/src/classes/validators/MessageCommandFlagValidator.ts
+++ b/packages/core/src/classes/validators/MessageCommandFlagValidator.ts
@@ -42,6 +42,17 @@ export class MessageCommandFlagValidators extends BaseCommandValidators {
         .boolean({ message: 'Expected boolean for .multiple' })
         .optional();
 
+    public static accept = MessageCommandFlagValidators.s
+        .union([
+            MessageCommandFlagValidators.s
+                .literal('string', { equalsOptions: { message: 'Expected "string" for .accept' } })
+                .optional(),
+            MessageCommandFlagValidators.s
+                .literal('boolean', { equalsOptions: { message: 'Expected "boolean" for .accept' } })
+                .optional(),
+        ])
+        .optional();
+
     public static validate = MessageCommandFlagValidators.s
         .instance(Function, { message: 'Expected a function for .validate' })
         .optional();
@@ -91,6 +102,10 @@ export class MessageCommandFlagValidators extends BaseCommandValidators {
         MessageCommandFlagValidators.multiple.setValidationEnabled(MessageCommandFlagValidators.isValidationEnabled).parse(multiple);
     }
 
+    public static isValidAccept(accept: unknown): asserts accept is MessageCommandFlagBuilderData['accept'] {
+        MessageCommandFlagValidators.accept.setValidationEnabled(MessageCommandFlagValidators.isValidationEnabled).parse(accept);
+    }
+
     public static isValidValidate(validate: unknown): asserts validate is MessageCommandFlagBuilderData['validate'] {
         MessageCommandFlagValidators.validate.setValidationEnabled(MessageCommandFlagValidators.isValidationEnabled).parse(validate);
     }
@@ -109,6 +124,7 @@ export class MessageCommandFlagValidators extends BaseCommandValidators {
         MessageCommandFlagValidators.isValidRequired(opt.required);
         MessageCommandFlagValidators.isValidMandatory(opt.mandatory);
         MessageCommandFlagValidators.isValidMultiple(opt.multiple);
+        MessageCommandFlagValidators.isValidAccept(opt.accept);
         MessageCommandFlagValidators.isValidValidate(opt.validate);
         MessageCommandFlagValidators.isValidResolveValue(opt.resolve_value);
     }

--- a/packages/core/src/classes/validators/MessageCommandFlagValidator.ts
+++ b/packages/core/src/classes/validators/MessageCommandFlagValidator.ts
@@ -21,10 +21,13 @@ export class MessageCommandFlagValidators extends BaseCommandValidators {
 
     public static default_values = MessageCommandFlagValidators.s
         .union([
-            MessageCommandFlagValidators.s.string({ message: 'Expected string as message command flag default value' }),
-            MessageCommandFlagValidators.s.boolean({ message: 'Expected boolean as message command flag default value' }),
+            MessageCommandFlagValidators.s
+                .string({ message: 'Expected string as message command flag default value' })
+                .array({ message: 'Expected array as message command flag default values' }),
+            MessageCommandFlagValidators.s
+                .boolean({ message: 'Expected boolean as message command flag default value' })
+                .array({ message: 'Expected array as message command flag default values' }),
         ])
-        .array({ message: 'Expected array as message command flag default values' })
         .optional();
 
     public static required = MessageCommandFlagValidators.s

--- a/packages/core/src/classes/validators/MessageCommandValidators.ts
+++ b/packages/core/src/classes/validators/MessageCommandValidators.ts
@@ -1,6 +1,7 @@
 import { MessageCommandOptionValidators } from './MessageCommandOptionValidators.js';
 import type { MessageCommandBuilderData } from '../builders/MessageCommandBuilder.js';
 import { BaseCommandValidators } from './BaseCommandValidators.js';
+import { MessageCommandFlagValidators } from './MessageCommandFlagValidator.js';
 
 export class MessageCommandValidators extends BaseCommandValidators {
     public static name = MessageCommandValidators.s
@@ -22,6 +23,10 @@ export class MessageCommandValidators extends BaseCommandValidators {
         .boolean({ message: 'Expected boolean for .validate_options' })
         .optional();
 
+    public static validate_flags = MessageCommandValidators.s
+        .boolean({ message: 'Expected boolean for .validate_flags' })
+        .optional();
+
     public static dm_permission = MessageCommandValidators.s
         .boolean({ message: 'Expected boolean for .dm_permission' })
         .optional();
@@ -32,6 +37,10 @@ export class MessageCommandValidators extends BaseCommandValidators {
 
     public static options = MessageCommandOptionValidators.MessageCommandOptionResolvable
         .array({ message: 'Expected an array for message command options' })
+        .optional();
+
+    public static flags = MessageCommandFlagValidators.MessageCommandFlagResolvable
+        .array({ message: 'Expected an array for message command flags' })
         .optional();
 
     public static isValidName(name: unknown): asserts name is MessageCommandBuilderData['name'] {
@@ -50,6 +59,10 @@ export class MessageCommandValidators extends BaseCommandValidators {
         MessageCommandValidators.validate_options.setValidationEnabled(MessageCommandValidators.isValidationEnabled).parse(parseOptions);
     }
 
+    public static isValidValidateFlags(parseFlags: unknown): asserts parseFlags is MessageCommandBuilderData['validate_flags'] {
+        MessageCommandValidators.validate_flags.setValidationEnabled(MessageCommandValidators.isValidationEnabled).parse(parseFlags);
+    }
+
     public static isValidDMPermission(DMPermission: unknown): asserts DMPermission is MessageCommandBuilderData['dm_permission'] {
         MessageCommandValidators.dm_permission.setValidationEnabled(MessageCommandValidators.isValidationEnabled).parse(DMPermission);
     }
@@ -60,5 +73,9 @@ export class MessageCommandValidators extends BaseCommandValidators {
 
     public static isValidOptions(options: unknown): asserts options is MessageCommandBuilderData['options'] {
         MessageCommandValidators.options.setValidationEnabled(MessageCommandValidators.isValidationEnabled).parse(options);
+    }
+
+    public static isValidFlags(flags: unknown): asserts flags is MessageCommandBuilderData['flags'] {
+        MessageCommandValidators.flags.setValidationEnabled(MessageCommandValidators.isValidationEnabled).parse(flags);
     }
 }

--- a/packages/core/src/types/constants.ts
+++ b/packages/core/src/types/constants.ts
@@ -14,7 +14,9 @@ export enum CommandHaltReason {
     Cooldown,
     InvalidArguments,
     MissingArguments,
-    PreconditionTrigger
+    PreconditionTrigger,
+    InvalidFlags,
+    MissingFlags
 }
 
 export enum RecipleModuleStatus {

--- a/packages/core/src/types/structures.ts
+++ b/packages/core/src/types/structures.ts
@@ -109,6 +109,7 @@ export interface CommandPreconditionResultHaltTriggerData<T extends CommandType>
 export interface CommandData {
     name?: string;
     prefix?: string;
+    flags: { name: string; value: (string|boolean)[]; }[];
     args: string[];
     raw: string;
     rawArgs: string;

--- a/packages/core/src/types/structures.ts
+++ b/packages/core/src/types/structures.ts
@@ -8,6 +8,7 @@ import type { MessageCommandOptionValue } from '../classes/structures/MessageCom
 import type { CooldownSweeperOptions } from '../classes/managers/CooldownManager.js';
 import type { CommandHaltReason, CommandType } from './constants.js';
 import type { Cooldown } from '../classes/structures/Cooldown.js';
+import type { MessageCommandFlagValue } from '../classes/structures/MessageCommandFlagValue.js';
 
 // Config
 export interface RecipleClientConfig {
@@ -66,7 +67,10 @@ export type AnySlashCommandOptionData = AnyNonSubcommandSlashCommandOptionData|A
 export type CommandHaltTriggerData<T extends CommandType> =
     | CommandErrorHaltTriggerData<T>
     | CommandCooldownHaltTriggerData<T>
-    | (T extends CommandType.MessageCommand ? CommandInvalidArgumentsHaltTriggerData<T> | CommandMissingArgumentsHaltTriggerData<T> : never)
+    | (T extends CommandType.MessageCommand
+        ? CommandInvalidArgumentsHaltTriggerData<T> | CommandMissingArgumentsHaltTriggerData<T> | CommandInvalidFlagsHaltTriggerData<T> | CommandMissingFlagsHaltTriggerData<T>
+        : never
+    )
     | CommandPreconditionResultHaltTriggerData<T>;
 
 export interface BaseCommandHaltTriggerData<T extends CommandType> {
@@ -99,6 +103,16 @@ export interface CommandInvalidArgumentsHaltTriggerData<T extends CommandType> e
 export interface CommandMissingArgumentsHaltTriggerData<T extends CommandType> extends BaseCommandHaltTriggerData<T> {
     reason: CommandHaltReason.MissingArguments;
     missingOptions: Collection<string, MessageCommandOptionValue>;
+}
+
+export interface CommandInvalidFlagsHaltTriggerData<T extends CommandType> extends BaseCommandHaltTriggerData<T> {
+    reason: CommandHaltReason.InvalidFlags;
+    invalidFlags: Collection<string, MessageCommandFlagValue>;
+}
+
+export interface CommandMissingFlagsHaltTriggerData<T extends CommandType> extends BaseCommandHaltTriggerData<T> {
+    reason: CommandHaltReason.MissingFlags;
+    missingFlags: Collection<string, MessageCommandFlagValue>;
 }
 
 export interface CommandPreconditionResultHaltTriggerData<T extends CommandType> extends BaseCommandHaltTriggerData<T>, Omit<CommandPreconditionResultData, 'executeData'> {

--- a/packages/message-command-utils/src/helpers/createMessageCommandUsage.ts
+++ b/packages/message-command-utils/src/helpers/createMessageCommandUsage.ts
@@ -35,15 +35,16 @@ export function createMessageCommandUsage(data: MessageCommandResolvable, option
 
     if (options?.flags?.include !== false && command.flags) for (const flagData of command.flags) {
         const flag = isJSONEncodable(flagData) ? flagData.toJSON() : flagData;
-        const brackets = flag.mandatory
-            ? options?.flags?.flagBrackets?.mandatory ?? ['<', '>']
-            : flag.required
-                ? options?.flags?.flagBrackets?.required ?? ['<', '>']
-                : options?.flags?.flagBrackets?.optional ?? ['[', ']'];
+        const brackets = flag.required
+            ? options?.flags?.flagBrackets?.required ?? ['<', '>']
+            : options?.flags?.flagBrackets?.optional ?? ['[', ']'];
+        const mandatory = options?.flags?.flagBrackets?.mandatory ?? ['', '']
 
         let value = `${options?.flags?.useShort ? '-' + flag.short : '--' + flag.name}`;
 
         if (options?.flags?.showValueType) value += `=${brackets[0]}${flag.value_type === 'string' ? 'string' : 'boolean'}${flag.multiple ? '...' : ''}${brackets[1]}`;
+
+        usage += ` ${mandatory[0]}${value}${mandatory[1]}`;
     }
 
     return usage;

--- a/packages/message-command-utils/src/helpers/createMessageCommandUsage.ts
+++ b/packages/message-command-utils/src/helpers/createMessageCommandUsage.ts
@@ -43,7 +43,7 @@ export function createMessageCommandUsage(data: MessageCommandResolvable, option
 
         let value = `${options?.flags?.useShort ? '-' + flag.short : '--' + flag.name}`;
 
-        if (options?.flags?.showValueType) value += `=${brackets[0]}${flag.accept === 'string' ? 'string' : 'boolean'}${flag.multiple ? '...' : ''}${brackets[1]}`;
+        if (options?.flags?.showValueType) value += `=${brackets[0]}${flag.value_type === 'string' ? 'string' : 'boolean'}${flag.multiple ? '...' : ''}${brackets[1]}`;
     }
 
     return usage;

--- a/packages/message-command-utils/src/helpers/createMessageCommandUsage.ts
+++ b/packages/message-command-utils/src/helpers/createMessageCommandUsage.ts
@@ -3,6 +3,16 @@ import { isJSONEncodable } from 'discord.js';
 
 export interface CreateMessageCommandUsageOptions {
     prefix?: string;
+    flags?: {
+        include?: boolean;
+        useShort?: boolean;
+        showValueType?: boolean;
+        flagBrackets?: {
+            required?: [string, string];
+            mandatory?: [string, string];
+            optional?: [string, string];
+        }
+    };
     optionBrackets?: {
         required?: [string, string];
         optional?: [string, string];
@@ -21,6 +31,19 @@ export function createMessageCommandUsage(data: MessageCommandResolvable, option
             : options?.optionBrackets?.optional ?? ['[', ']']
 
         usage += ` ${brackets[0]}${option.name}${brackets[1]}`;
+    }
+
+    if (options?.flags?.include !== false && command.flags) for (const flagData of command.flags) {
+        const flag = isJSONEncodable(flagData) ? flagData.toJSON() : flagData;
+        const brackets = flag.mandatory
+            ? options?.flags?.flagBrackets?.mandatory ?? ['<', '>']
+            : flag.required
+                ? options?.flags?.flagBrackets?.required ?? ['<', '>']
+                : options?.flags?.flagBrackets?.optional ?? ['[', ']'];
+
+        let value = `${options?.flags?.useShort ? '-' + flag.short : '--' + flag.name}`;
+
+        if (options?.flags?.showValueType) value += `=${brackets[0]}${flag.accept === 'string' ? 'string' : 'boolean'}${flag.multiple ? '...' : ''}${brackets[1]}`;
     }
 
     return usage;


### PR DESCRIPTION
Add a new kind of options that can be used similar to CLI commands.

## Example
```js
new MessageCommandBuilder()
    .setName('command')
    .setDescription('My command')
    .addFlag(flag => flag
        .setName('flag')
        .setDescription('My flag')
        .setValueType('string')
    )
```

```
!command --flag MyValue
```